### PR TITLE
move default attributes to separate macro

### DIFF
--- a/lib/opencensus/trace.ex
+++ b/lib/opencensus/trace.ex
@@ -1,6 +1,30 @@
 defmodule Opencensus.Trace do
   @doc "Wraps the given block in a tracing child span with the given label/name and optional attributes"
   defmacro with_child_span(label, attributes \\ quote(do: %{}), do: block) do
+    quote do
+      parent_span_ctx = :ocp.current_span_ctx()
+
+      new_span_ctx =
+        :oc_trace.start_span(unquote(label), parent_span_ctx, %{
+          :attributes => unquote(attributes)
+        })
+
+      :ocp.with_span_ctx(new_span_ctx)
+
+      try do
+        unquote(block)
+      after
+        :oc_trace.finish_span(new_span_ctx)
+        :ocp.with_span_ctx(parent_span_ctx)
+      end
+    end
+  end
+
+  @doc """
+  Constructs an attribute map from an optional map of attributes and attributes
+  for the current calling environment.
+  """
+  defmacro default_attributes(attributes \\ quote(do: %{})) do
     line = __CALLER__.line
     module = __CALLER__.module
     file = __CALLER__.file
@@ -14,17 +38,6 @@ defmodule Opencensus.Trace do
           file: unquote(file),
           function: unquote(function)
         })
-
-      parent_span_ctx = :ocp.current_span_ctx()
-      new_span_ctx = :oc_trace.start_span(unquote(label), parent_span_ctx, unquote(attributes))
-      :ocp.with_span_ctx(new_span_ctx)
-
-      try do
-        unquote(block)
-      after
-        :oc_trace.finish_span(new_span_ctx)
-        :ocp.with_span_ctx(parent_span_ctx)
-      end
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule OpencensusElixir.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       test_coverage: [tool: ExCoveralls],
+      aliases: aliases(),
       preferred_cli_env: [
         coveralls: :test,
         "coveralls.html": :test,
@@ -40,6 +41,12 @@ defmodule OpencensusElixir.MixProject do
       {:excoveralls, "~> 0.10.3", only: [:test]},
       {:dialyxir, ">= 0.0.0", runtime: false, only: [:dev, :test]},
       {:junit_formatter, ">= 0.0.0", only: [:test]}
+    ]
+  end
+
+  defp aliases do
+    [
+      test: "test --no-start"
     ]
   end
 end

--- a/test/opencensus_test.exs
+++ b/test/opencensus_test.exs
@@ -1,7 +1,38 @@
+defmodule Span do
+  require Record
+  Record.defrecord(:span, Record.extract(:span, from_lib: "opencensus/include/opencensus.hrl"))
+end
+
+defmodule PidAttributesReporter do
+  import Span
+
+  def init(pid) do
+    pid
+  end
+
+  def report(spans, pid) do
+    Enum.each(spans, fn span ->
+      send(pid, {:attributes, span(span, :attributes)})
+    end)
+  end
+end
+
 defmodule OpencensusTest do
   use ExUnit.Case
+  import Opencensus.Trace
 
-  test "do some span or something" do
-    assert true
+  test "verify attributes", _state do
+    :application.load(:opencensus)
+    :application.set_env(:opencensus, :send_interval_ms, 1)
+    :application.set_env(:opencensus, :reporter, {PidAttributesReporter, self()})
+
+    :application.ensure_all_started(:opencensus)
+    :application.ensure_all_started(:opencensus_elixir)
+
+    with_child_span "child_span", default_attributes(%{"attr-1" => "value-1"}) do
+      :do_something
+    end
+
+    assert_receive {:attributes, %{"attr-1" => "value-1", :module => OpencensusTest}}, 1_000
   end
 end


### PR DESCRIPTION
I don't really like this, but it is the only thing I've been able to come up with so far.

Because traces should have a near zero cost I am hesitant to have anything included by default that is not absolutely necessary to fulfill the spec.

In a perfect world there would be a way for at run time the user to define what attributes from these defaults are to be included in each span, but I don't know of one that doesn't involve looking up application env data or some other ets table (maybe `persistent_term` would work in the future).

Open to alternatives.